### PR TITLE
favicon issue fix

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -27,10 +27,14 @@ var metadata = function() {
       iconTag = $('link[rel=icon]')
     }
 
-    if(typeof(iconTag.length) !== 'undefined' && iconTag.length > 1) {
-      responseObject.faviconUrl = (typeof(iconTag[0].attribs) !== 'undefined' && typeof(iconTag[0].attribs.href) !== 'undefined') ? iconTag[0].attribs.href : null;
-    } else {
-      responseObject.faviconUrl = (typeof(iconTag.attribs) !== 'undefined' && typeof(iconTag.attribs.href) !== 'undefined') ? iconTag[0].attribs.href : null;
+    // using the attr method of the cheerio/jquery object to get href. 
+    // in case of multiple iconTag elements, it will use the first one
+    responseObject.faviconUrl = iconTag.attr('href') || null
+
+    // resolving the url
+    // this is in case the icon path is a relative url
+    if(responseObject.faviconUrl){
+      responseObject.faviconUrl = url.resolve(address,responseObject.faviconUrl);
     }
 
     //if there's no icon in the HTML, try root/favicon.ico and see if that 200's


### PR DESCRIPTION
Fixes the issue, when the icon is found in the head, but ignored by the script. This will get the correct icon path, and will save some extra requests pinging the /favicon.ico
Also, this will resolve the relative url addresses to the full path.

To test, try:
http://www.learning-mind.com/
http://todomvc.com/
https://help.github.com/articles/dealing-with-non-fast-forward-errors/
http://www.iflscience.com/chemistry/do-try-home
